### PR TITLE
Fix service name in deployment script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,5 +29,6 @@ jobs:
             python3 -m venv venv
             source venv/bin/activate
             pip install -r requirements.txt
-            sudo systemctl restart fastapi-app
+            sudo systemctl daemon-reload
+            sudo systemctl restart fastapi-book-project
           EOF


### PR DESCRIPTION
## Description  
- Added `sudo systemctl daemon-reload` to deply script
- 
## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.